### PR TITLE
:bug: Fix KeyError when load luts models

### DIFF
--- a/nodes/luts.py
+++ b/nodes/luts.py
@@ -117,7 +117,7 @@ class LutsAdvanced:
         return {
             "required": {
                 "image": ("IMAGE",),
-                "lut_file": (folder_paths.get_filename_list("luts"), {"default": "Cinematic.cube"}),
+                "lut_file": (os.listdir(os.path.join(folder_paths.models_dir, "luts")), {"default": "Cinematic.cube"}),
                 "gamma_correction": ("BOOLEAN", {"default": True}),
                 "clip_values": ("BOOLEAN", {"default": True}),
                 "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.1}),


### PR DESCRIPTION
I got KeyError when load lut models, and I found that `get_filename_list` can not get files which are in the `luts` folder.

<img width="1702" height="545" alt="image" src="https://github.com/user-attachments/assets/4de71de8-b3f1-4a67-a176-32874db2066c" />

My ComfyUI version: 0.3.48([3dfefc8](https://github.com/comfyanonymous/ComfyUI/commit/3dfefc88d00bde744b729b073058a57e149cddc1))